### PR TITLE
feat: add json output option

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,5 +17,12 @@ pipeline {
                 sh 'make test'
             }
         }
+
+        stage('Integration testing') {
+            steps {
+                sh 'bin/jdbcstats --file jdbc.log.test --output ttable --rows 10'
+                sh 'bin/jdbcstats --file jdbc.log.test --output json --rows 5'
+            }
+        }
     }
 }

--- a/bin/jdbcstats
+++ b/bin/jdbcstats
@@ -4,9 +4,7 @@ BASEDIR="$(dirname "$0")/.."
 VENV=~/.jdbclog/bin/activate
 
 if [[ -f $VENV ]]; then
-    echo "$@"
-    . $VENV &&\
-        which python &&\
+    . $VENV > /dev/null &&\
         python $BASEDIR/parser/main.py $@
 else
     echo "

--- a/parser/main.py
+++ b/parser/main.py
@@ -1,4 +1,5 @@
 import click
+import json
 from terminaltables import AsciiTable
 
 values = {}
@@ -38,27 +39,52 @@ def dict2arr(entry):
     return [entry["query"][:140], entry["count"], entry["tot_ms"], entry["avg_ms"]]
 
 
-def sortstat(sortkey, rows=20):
+def resentry2json(entry):
+    return {
+        "query": entry[0],
+        "count": entry[1],
+        "total_ms": entry[2],
+        "avg_ms": entry[3],
+    }
+
+
+def print_ttable(data):
+    table = AsciiTable([["Query", "Count", "Total ms", "Avg ms"]] + data)
+    print(table.table)
+
+
+def print_json(data):
+    json_output = {"results": list(map(resentry2json, data))}
+    print(json.dumps(json_output, indent=4))
+
+
+output_options = {"ttable": print_ttable, "json": print_json}
+
+
+def sortstat(sortkey, rows, outtype):
     val_list = list(values.values())
 
     table_data = sorted(val_list, key=lambda d: d[sortkey], reverse=True)
-    output = list(map(dict2arr, table_data[:rows]))
-    table = AsciiTable([["Query", "Count", "Total ms", "Avg ms"]] + output)
-    print(table.table)
+    outdata = list(map(dict2arr, table_data[:rows]))
+
+    if outtype in output_options:
+        output_options[outtype](outdata)
+    else:
+        print("Invalid output option specified")
 
 
 @click.command()
 @click.option("--file", help="The JDBC file path")
 @click.option("--sort", default="avg_ms", help="The sort key")
 @click.option("--rows", default=20, help="The number of rows to return")
-def parseme(file, sort, rows):
-    print(file)
+@click.option("--output", default="ttable", help="The type of ouput: [ttable|json]")
+def parseme(file, sort, rows, output):
     fd = open(file)
     for line in fd:
         load_stats(line)
     fd.close()
 
-    sortstat(sort, rows)
+    sortstat(sort, rows, output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added the `--output` option for the command with the following values:
- json a json representation of the output
- ttable the terminal table print