### PR TITLE
chore: refactor Jenkinsfile to use proper agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker { 
-            image 'python:3.7-stretch' 
-            args '--user root'
+            image 'jenkins-agent:python-3.7' 
+            args '--user jenkins'
         }
     }
     environment {


### PR DESCRIPTION
Now using the jenkins-docker-agent for python builds with the appropriate user (non-root) created ad-hoc.
When running the build as root user some files were left behind owned by root making it impossible for jenkins user to delete